### PR TITLE
Fix: fixed movement loggic add

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/src/main/java/com/yutnori/controller/PieceMoveController.java
+++ b/src/main/java/com/yutnori/controller/PieceMoveController.java
@@ -17,21 +17,32 @@ public class PieceMoveController {
                 piece.moveTo(start);
 
                 // 첫 moveTo 후에도 추가로 이동
-                Cell next = board.getNextCell(start, steps);
+                Cell next = board.getDestinationCell(start, steps, board, piece);
                 if (next != null && next != start) {
                     piece.moveTo(next);
                 }
                 handleGrouping(piece);  // ✅ grouping 처리
             }
+
+
             return;
         }
-
-        Cell current = piece.getPosition();
-        Cell next = board.getDestinationCell(current, steps);
-        if (next != null) {
-            piece.moveTo(next);
-            handleGrouping(piece);  // ✅ grouping 처리
+        if (steps == -1) {
+            if(!piece.history.isEmpty()){
+                System.out.println(piece.history.peek());
+                piece.moveTo(board.getCells().get(piece.history.pop()));
+                handleGrouping(piece);
+            }
         }
+        else{
+            Cell current = piece.getPosition();
+            Cell next = board.getDestinationCell(current, steps, board, piece);
+            if (next != null) {
+                piece.moveTo(next);
+                handleGrouping(piece);  // ✅ grouping 처리
+            }
+        }
+
     }
 
     // 말 잡기 로직: 다른 플레이어 말이 있으면 잡고 원위치

--- a/src/main/java/com/yutnori/model/Board.java
+++ b/src/main/java/com/yutnori/model/Board.java
@@ -19,7 +19,7 @@ public abstract class Board {
         return cells;
     }
 
-    public abstract Cell getDestinationCell(Cell current, int steps); // Cell의 NextCell과 겹치지 않게 이름 변경
+    public abstract Cell getDestinationCell(Cell current, int steps, Board board, Piece piece); // Cell의 NextCell과 겹치지 않게 이름 변경
 
 //    public abstract boolean isValidMove(int currentId, int steps);
 

--- a/src/main/java/com/yutnori/model/Cell.java
+++ b/src/main/java/com/yutnori/model/Cell.java
@@ -1,7 +1,9 @@
 package com.yutnori.model;
 
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
+import java.util.Stack;
 
 public class Cell {
     private int id;

--- a/src/main/java/com/yutnori/model/HexagonBoard.java
+++ b/src/main/java/com/yutnori/model/HexagonBoard.java
@@ -121,7 +121,7 @@ public class HexagonBoard extends Board {
     }
 
     @Override
-    public Cell getDestinationCell(Cell current, int steps) {
+    public Cell getDestinationCell(Cell current, int steps, Board board, Piece piece) {
         // 1. 기본 이동
         int id = (current == null ? 0 : current.getId() + steps);
         if (id < 0) id = 0;

--- a/src/main/java/com/yutnori/model/PentagonBoard.java
+++ b/src/main/java/com/yutnori/model/PentagonBoard.java
@@ -112,7 +112,7 @@ public class PentagonBoard extends Board {
     }
 
     @Override
-    public Cell getDestinationCell(Cell current, int steps) {
+    public Cell getDestinationCell(Cell current, int steps, Board board, Piece piece) {
         // 1. 기본 이동
         int id = (current == null ? 0 : current.getId() + steps);
         if (id < 0) id = 0;

--- a/src/main/java/com/yutnori/model/Piece.java
+++ b/src/main/java/com/yutnori/model/Piece.java
@@ -1,10 +1,8 @@
 package com.yutnori.model;
 
 import java.awt.*;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.List;
-import java.util.Deque;
 
 public class Piece {
     private int id;
@@ -14,7 +12,34 @@ public class Piece {
     private Player owner;
     private boolean isOnBoard = false;
     private boolean isFinished = false; // 한바퀴 다 돌고 온 말인지 여부를 판별하기 위한 boolean
-    private final Deque<Cell> history = new ArrayDeque<>();
+    public Stack<Integer> history = new Stack<Integer>() {
+        @Override
+        public Integer push(Integer item) {
+
+            return super.push(item);
+        }
+
+        @Override
+        public Integer pop() {
+            return super.pop();
+        }
+
+        @Override
+        public synchronized Integer peek() {
+            return super.peek();
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return super.isEmpty();
+        }
+
+        @Override
+        public int size() {
+            return super.size();
+        }
+
+    };
 
     public Piece(int id, Player owner) {
         this.id = id;

--- a/src/main/java/com/yutnori/model/SquareBoard.java
+++ b/src/main/java/com/yutnori/model/SquareBoard.java
@@ -16,9 +16,23 @@ public class SquareBoard extends Board {
         for (int i = 0; i < 19; i++) {
             m.put(i,(i+1)%19);
         }
-        m.put(20,21); m.put(21,22); m.put(22,23); m.put(23,24);
+        m.put(20,21); m.put(21,22); m.put(22,23); m.put(23,24); m.put(24,15);
         m.put(25,26); m.put(26,27); m.put(27,28); m.put(28,29); m.put(29,0);
         nextPositionGeneral = Collections.unmodifiableMap(m);
+    }
+    private static final Map<Integer, Integer> nextPositionSpecial;
+    static {
+        Map<Integer,Integer> m = new HashMap<>();
+        for (int i = 0; i < 19; i++) {
+            if (i == 5) {m.put(5,20); continue; }
+            if (i == 10) {m.put(10,25); continue;}
+            m.put(i,(i+1));
+        }
+
+        m.put(20,21); m.put(21,22); m.put(22,28); m.put(23,24); m.put(24,15);
+        m.put(25,26); m.put(26,27); m.put(27,28); m.put(28,29); m.put(29,0);
+
+        nextPositionSpecial = Collections.unmodifiableMap(m);
     }
     public SquareBoard() {
         initializeCells();
@@ -69,6 +83,7 @@ public class SquareBoard extends Board {
 
 
         nodePositions.put(22, new Point(centreX, centreY)); // center node (센터 노드)
+        nodePositions.put(27, new Point(centreX, centreY));
 
 
         // 대각선 노드들의 위치 정의.
@@ -106,61 +121,18 @@ public class SquareBoard extends Board {
     }
 
     @Override
-    public Cell getDestinationCell(Cell current, int steps) {
+    public Cell getDestinationCell(Cell current, int steps, Board board, Piece piece) {
         if (current == null) return cells.get(0);
         Cell destCell = current;
-        /*
-        빽도가 아니면 현재 위치가 분기를 만드는 셀인지 확인 후,
-        맞다면 안쪽 브랜치(지름길)로 이동 후 다음 셀로 한 칸 씩 이동 -> getNextBranchCell -> getNextCell * (steps -1) 실행
-        아니라면 그냥 다음 셀로 한 칸 씩 이동 -> getNextCell * step 실행
-        이러면 왼쪽 위, 즉 10, 25, 26에서 이동할 때 NextCell로 이동하다보면 오류 발생
-        25에서 걸이 나오면 NextCell만 실행하는데, 이러면 25->26->22->23과 같은 형태가 됨.
-        왜냐하면 22, 중앙의 ne
-        */
-        /*
-        if (steps > 0){
-            if (isBranchCorner(current.getId())) {
-                destCell = this.cells.get(destCell.getId()).getNextBranchCell();
-                for (int i = 0; i < steps - 1; i++) {
-                    destCell = this.cells.get(destCell.getId()).getNextCell();
-                }
-            }
-            else{
-                for (int i = 0; i < steps; i++) {
-                    destCell = this.cells.get(destCell.getId()).getNextCell();
-                }
-            }
-        }
-        else {
-            destCell = this.cells.get(destCell.getId()).getPreviousCell();
+
+        for (int i = 0; i < steps; i++){
+            piece.history.push(destCell.getId());
+            System.out.println("history : " + piece.history);
+            if (i==0) destCell =  board.getCells().get(nextPositionSpecial.get(destCell.getId()));
+            else destCell =  board.getCells().get(nextPositionGeneral.get(destCell.getId()));
         }
 
 
-         */
-
-
-
-        // 1. 기본 이동
-        /*
-        int id = (current == null ? 0 : current.getId() + steps);
-        if (id < 0) id = 0;
-        if (id >= cells.size()) id = cells.size() - 1;
-
-         */
-        // 2. “딱 코너에 착지했다면” 안쪽으로 이동
-        /*
-        if (isCorner(id)) {
-            Integer branchId = CORNER_BRANCH.get(id);
-            if (branchId != null) {
-                return cells.get(branchId);
-            }
-        }
-*/
-
-
-
-
-        // 3,  그 외는 그대로
         return destCell;
     }
 

--- a/src/main/java/com/yutnori/model/Yut.java
+++ b/src/main/java/com/yutnori/model/Yut.java
@@ -23,12 +23,16 @@ public class Yut {
     public void throwRandomYut() {
         double r = Math.random();  // 0.0 ~ 1.0
         int result;
+        if (r < 0.5) result = 3;
+        else  result=-1;
+        /*
         if (r < 1.0 / 16) result = -1;         // 빽도
         else if (r < 4.0 / 16) result = 1;     // 도
         else if (r < 10.0 / 16) result = 2;    // 개
         else if (r < 14.0 / 16) result = 3;    // 걸
-        else if (r < 15.0 / 16) result = 4;    // 윷
+        else if (r < 15.0/ 16) result = 4;    // 윷
         else result = 5;                       // 모
+        */
         results.add(result);
     }
 

--- a/src/main/java/com/yutnori/model/Yut.java
+++ b/src/main/java/com/yutnori/model/Yut.java
@@ -23,16 +23,15 @@ public class Yut {
     public void throwRandomYut() {
         double r = Math.random();  // 0.0 ~ 1.0
         int result;
-        if (r < 0.5) result = 3;
-        else  result=-1;
-        /*
+
+
         if (r < 1.0 / 16) result = -1;         // 빽도
         else if (r < 4.0 / 16) result = 1;     // 도
         else if (r < 10.0 / 16) result = 2;    // 개
         else if (r < 14.0 / 16) result = 3;    // 걸
         else if (r < 15.0/ 16) result = 4;    // 윷
         else result = 5;                       // 모
-        */
+        
         results.add(result);
     }
 


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `fix/draft-for-movement-logic`
- 작업 내용 요약:
1. 해쉬맵 기준으로 노드 연결
2. Special, General 2가지로 나눔 
- special은 노드가 시작점일때 연결되는 노드
- general은 기본 이동 경로
3. Piece class에 history stack 추가 (빽도용 경로저장 스택)
4. getDestinationCell 파라미터 , 로직 수정
5. 기타 로직을 위한 수정


## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #15 

## 🙋‍♂️ 리뷰어에게 한 마디
이동 로직 끝! 
현재 사각형만 완성한 상태-> 오각형, 육각형 해쉬맵 추가예정
이제 업기, 잡기 구현 하면 로직은 끝 