### PR TITLE
[Feat] 업은 말에 대한 정보 표시

### DIFF
--- a/src/main/java/com/yutnori/YutnoriApplication.java
+++ b/src/main/java/com/yutnori/YutnoriApplication.java
@@ -4,7 +4,6 @@ import com.yutnori.controller.GameController;
 
 
 import javax.swing.*;
-import java.awt.*;
 
 public class YutnoriApplication {
     public static void main(String[] args) {

--- a/src/main/java/com/yutnori/YutnoriApplication.java
+++ b/src/main/java/com/yutnori/YutnoriApplication.java
@@ -4,9 +4,11 @@ import com.yutnori.controller.GameController;
 
 
 import javax.swing.*;
+import java.awt.*;
 
 public class YutnoriApplication {
     public static void main(String[] args) {
+        // Game Controller 생성 및 실행
         SwingUtilities.invokeLater(() -> {
             GameController controller = new GameController();
         });

--- a/src/main/java/com/yutnori/controller/GameController.java
+++ b/src/main/java/com/yutnori/controller/GameController.java
@@ -103,6 +103,8 @@ public class GameController {
                 return;
             }
 
+
+
             PieceMoveController moveController = new PieceMoveController(game.getBoard());
             moveController.movePiece(selectedPiece, selectedStep);
 

--- a/src/main/java/com/yutnori/controller/PieceMoveController.java
+++ b/src/main/java/com/yutnori/controller/PieceMoveController.java
@@ -17,6 +17,7 @@ public class PieceMoveController {
     public void movePiece(Piece piece, int steps) {
         if (piece.isFinished()) return;
 
+
         // 만약 piece가 업힌 말이라면 → 리더 기준으로 처리
         if (piece.getGroupLeader() != null) {
             piece = piece.getGroupLeader();
@@ -97,6 +98,7 @@ public class PieceMoveController {
                 // 이미 어느 쪽이든 그룹에 속하면 병합
                 Piece leader1 = piece.getGroupLeaderOrSelf();
                 Piece leader2 = other.getGroupLeaderOrSelf();
+
 
                 if (leader1 == leader2) return; // 이미 같은 그룹이면 무시
 

--- a/src/main/java/com/yutnori/model/Piece.java
+++ b/src/main/java/com/yutnori/model/Piece.java
@@ -116,8 +116,6 @@ public class Piece {
         }
         if (!moveTogetherPiece.contains(piece)) {
             moveTogetherPiece.add(piece);
-            // piece.addGroupingPiece(this); // 양방향 연결
-            System.out.println("Piece " + piece.getId() + " is grouped under Leader " + this.getId());
         }
     }
 

--- a/src/main/java/com/yutnori/model/Piece.java
+++ b/src/main/java/com/yutnori/model/Piece.java
@@ -110,12 +110,14 @@ public class Piece {
 
     public void setFinished(boolean finished) { isFinished = finished; } // setter method for isFinished.
     public void addGroupingPiece(Piece piece) {
+        piece.setGroupLeader(this);
         if (moveTogetherPiece == null) {
             moveTogetherPiece = new ArrayList<>();
         }
         if (!moveTogetherPiece.contains(piece)) {
             moveTogetherPiece.add(piece);
-            piece.addGroupingPiece(this); // 양방향 연결
+            // piece.addGroupingPiece(this); // 양방향 연결
+            System.out.println("Piece " + piece.getId() + " is grouped under Leader " + this.getId());
         }
     }
 

--- a/src/main/java/com/yutnori/view/GameView.java
+++ b/src/main/java/com/yutnori/view/GameView.java
@@ -122,6 +122,7 @@ public class GameView {
         List<Piece> movable = player.getPieces().stream()
                 .filter(p -> !p.isFinished())
                 .filter(p -> step != -1 || p.isOnBoard())
+                .filter(p -> p.getGroupLeader() == null)
                 .toList();
 
 
@@ -136,7 +137,20 @@ public class GameView {
 
         String[] options = new String[movable.size()];
         for (int i = 0; i < movable.size(); i++) {
-            options[i] = "말 " + (movable.get(i).getId() + 1);
+            Piece p = movable.get(i);
+            StringBuilder label = new StringBuilder("말 " + (p.getId() + 1));
+
+            // 업고 있는 말들 정보 추가
+            List<Piece> carried = p.getGroupingPieces();
+            if (carried != null && !carried.isEmpty()) {
+                label.append(" (업은 말: ");
+                for (int j = 0; j < carried.size(); j++) {
+                    label.append(carried.get(j).getId() + 1);  // 말 번호 1부터
+                    if (j != carried.size() - 1) label.append(", ");
+                }
+                label.append(")");
+            }
+            options[i] = label.toString();
         }
 
         int selected = JOptionPane.showOptionDialog(


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feature/Integrated-UI`
- 작업 내용 요약:
- UI 내에서 말에 대한 선택권이 있고 업은 말들을 표현할 때, 업은 (즉 grouping에서 group leader) 말만 선택할 수 있도록 하고, 해당 말이 무슨 말을 업었는지 보여주는 기능 구현

## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈


## 🙋‍♂️ 리뷰어에게 한 마디
자세한 작업 내용은 위의 "작업 내용 요약"을 참고해주세요.
이제 업은 말에 대한 정보 표시 (업은 말만 선택 가능, 그리고 해당 말이 어떤 말을 업었는지)가 구현되었습니다.