### PR TITLE
[Fix] 빽도 관련 issue resolve (빽도 악용 방지)

### DIFF
--- a/src/main/java/com/yutnori/controller/PieceMoveController.java
+++ b/src/main/java/com/yutnori/controller/PieceMoveController.java
@@ -41,29 +41,30 @@ public class PieceMoveController {
             return;
         }
         if (steps == -1) { // 빽도일 때 (말이 보드에 올라와 있음)
-            if(!piece.history.isEmpty()){
+            if(!piece.history.isEmpty()){ // history가 비어있지 않다면 (regular case)
                 piece.moveTo(board.getCells().get(piece.history.pop()));
                 this.isCaptured = handleCapture(piece);
                 handleGrouping(piece); // grouping 처리
+
+                if (piece.getPosition().getId() == 0) {
+                    piece.setPassedStartOnce(true);
+                }
                 checkFinishCondition(piece);
+            }
+            else { // history가 비어있다면 (왔던만큼 다시 빽도로 돌아가서 출발점에 있는 노드는 history가 비어있음), 그 상태에서 빽도가 또 들어온다면 finish 처리
+                if (piece.getPosition().getId() == 0 && piece.hasPassedStartOnce()) {
+                    finishPiece(piece);
+                }
             }
         }
         else { // Regular case (말이 보드에 올라와 있고, 빽도가 아님.)
             Cell current = piece.getPosition();
             Cell next = board.getDestinationCell(current, steps, board, piece);
             if (next != null) {
-                if (piece.isOnBoard() && next.getId() == 0 && piece.hasPassedStartOnce()) {
-                    finishPiece(piece);
-                } else {
-                    if (piece.isOnBoard() && piece.getPosition().getId() != 0 && next.getId() == 0) {
-                        piece.setPassedStartOnce(true); // 한 바퀴 돌았음을 기록
-                    }
-                    piece.moveTo(next);
-                    this.isCaptured = handleCapture(piece);
-                    handleGrouping(piece);
-                    checkFinishCondition(piece);
-                }
-
+                piece.moveTo(next);
+                this.isCaptured = handleCapture(piece);
+                handleGrouping(piece);
+                checkFinishCondition(piece);
             }
         }
     }

--- a/src/main/java/com/yutnori/model/Piece.java
+++ b/src/main/java/com/yutnori/model/Piece.java
@@ -74,8 +74,7 @@ public class Piece {
         isOnBoard = false;
         isFinished = false;
         moveTogetherPiece.clear(); // 업힌 말 초기화
-        // TODO: passedStartOnce 초기화 해야 함 (그냥 아래 줄 주석해제 하면 됨)
-        //  passedStartOnce = false;
+        passedStartOnce = false;
     }
 
     public Cell getPosition() { // to get the position of the piece


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feature/Integrated-UI`
- 작업 내용 요약: 사용자가 도 - 빽도 - 빽도를 던질 시, 혹은 윷을 던지고 계속 빽도가 나와 처음 출발점으로 돌아왔을때 한번 더 빽도가 나오면 finish 처리.

## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #43

## 🙋‍♂️ 리뷰어에게 한 마디
빽도 악용 가능성 근절을 위해 처음 출발점으로 다시 되돌아 왔을 때 (도 - 빽도 혹은 개 - 빽도 - 빽도 등으로), 한번 더 빽도가 나오면 finish 처리를 하도록 했습니다.