### PR TITLE
[Fix] finish and grouping/capturing order modified

### DIFF
--- a/src/main/java/com/yutnori/controller/PieceMoveController.java
+++ b/src/main/java/com/yutnori/controller/PieceMoveController.java
@@ -34,22 +34,27 @@ public class PieceMoveController {
                 if (next != null && next != start) {
                     piece.moveTo(next);
                 }
-                this.isCaptured = handleCapture(piece);
-                handleGrouping(piece);  // grouping 처리
                 checkFinishCondition(piece);
+                if (!piece.isFinished()) {
+                    this.isCaptured = handleCapture(piece);
+                    handleGrouping(piece);  // grouping 처리
+                }
             }
             return;
         }
         if (steps == -1) { // 빽도일 때 (말이 보드에 올라와 있음)
             if(!piece.history.isEmpty()){ // history가 비어있지 않다면 (regular case)
                 piece.moveTo(board.getCells().get(piece.history.pop()));
-                this.isCaptured = handleCapture(piece);
-                handleGrouping(piece); // grouping 처리
+
+                checkFinishCondition(piece);
+                if (!piece.isFinished()) {
+                    this.isCaptured = handleCapture(piece);
+                    handleGrouping(piece); // grouping 처리
+                }
 
                 if (piece.getPosition().getId() == 0) {
                     piece.setPassedStartOnce(true);
                 }
-                checkFinishCondition(piece);
             }
             else { // history가 비어있다면 (왔던만큼 다시 빽도로 돌아가서 출발점에 있는 노드는 history가 비어있음), 그 상태에서 빽도가 또 들어온다면 finish 처리
                 if (piece.getPosition().getId() == 0 && piece.hasPassedStartOnce()) {
@@ -74,9 +79,13 @@ public class PieceMoveController {
                     }
                 }
                 piece.moveTo(next);
-                this.isCaptured = handleCapture(piece);
-                handleGrouping(piece);
                 checkFinishCondition(piece);
+                if (!piece.isFinished()) {
+                    this.isCaptured = handleCapture(piece);
+                    handleGrouping(piece); // grouping 처리
+                }
+
+
 
             }
         }


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `feature/Integrated-UI`
- 작업 내용 요약:
- 잡기/업기 보다, finish를 먼저 함.
- 그러므로 도 - 빽도 등으로 출발점에 이미 있는 말을 끝내지는 말이 딱 출발점에 안착할 시 잡거나 업는 버그 현상 수정 완료.

## ✅ 작업 완료 내역 체크리스트

- [x] 기능 동작 확인
- [x] 테스트 코드 포함 (필요시)
- [x] 문서 및 주석 정리
- [x] 코드 컨벤션 준수

## 🔁 관련 이슈

## 🙋‍♂️ 리뷰어에게 한 마디
additional 버그 수정 완료. 테스트 후 더 버그 있을 시 보고 바랍니다.