### PR TITLE
fix: removed numberings in the nodes in javaFX version

### DIFF
--- a/src/main/java/com/yutnori/FXview/FXBoardView.java
+++ b/src/main/java/com/yutnori/FXview/FXBoardView.java
@@ -77,17 +77,6 @@ public class FXBoardView extends Pane implements BoardViewInterface { // JPanel 
                 gc.fillText("출발", p.x - 12, p.y + 5);
             }
 
-            else { // TODO: 현재 이 else문은 노드의 ID를 표시함. 디버깅 후 이 else문을 꼭 지워야 함
-                javafx.scene.text.Text text = new javafx.scene.text.Text(String.valueOf(id));
-                text.setFont(Font.font("Arial", 12));
-                double textWidth = text.getLayoutBounds().getWidth();
-                double textHeight = text.getLayoutBounds().getHeight();
-
-                gc.setFont(text.getFont());
-                gc.setFill(Color.GRAY);
-                gc.fillText(String.valueOf(id), (float)(p.x - textWidth / 2), (float)(p.y + textHeight / 4));
-            }
-
         }
     }
 


### PR DESCRIPTION
## 🔀 Pull Request 요약

- 관련 브랜치: `fix/removeNumber`
- 작업 내용 요약:
테스트용 FXboard의 cell id 출력 삭제

## ✅ 작업 완료 내역 체크리스트

- [ ] 기능 동작 확인
- [ ] 테스트 코드 포함 (필요시)
- [ ] 문서 및 주석 정리
- [ ] 코드 컨벤션 준수

## 🔁 관련 이슈

- Closes #66  

## 🙋‍♂️ 리뷰어에게 한 마디
UI부분 간단한 삭제입니다. 이제 FX view도 깔끔하게 숫자 지워졌습니다.